### PR TITLE
Use CodeMeta homepage in navbar-brand

### DIFF
--- a/themes/hugo-material/layouts/partials/nav.html
+++ b/themes/hugo-material/layouts/partials/nav.html
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-transparent navbar-color-on-scroll fixed-top navbar-expand-lg" color-on-scroll="100" id="sectionsNav">
     <div class="container">
       <div class="navbar-translate">
-        <a class="navbar-brand" href="https://demos.creative-tim.com/material-kit/index.html">
+        <a class="navbar-brand" href="https://codemeta.github.io/index.html">
           {{.Site.Title }} </a>
         <button class="navbar-toggler" type="button" data-toggle="collapse" aria-expanded="false" aria-label="Toggle navigation">
           <span class="sr-only">Toggle navigation</span>


### PR DESCRIPTION
Previously clicking on "The CodeMeta Project" took you to https://demos.creative-tim.com/material-kit/index.html