### PR TITLE
Split table of schema.org terms between Software and Person properties.

### DIFF
--- a/content/terms.Rmd
+++ b/content/terms.Rmd
@@ -11,26 +11,32 @@ library("dplyr")
 
 ## Terms from Schema.org
 
-Recognized properties for CodeMeta `Code` includes the following terms from <https://schema.org>.  These terms are part of the CodeMeta specification and can be used without any prefix. 
+Recognized properties for CodeMeta `SoftwareSourceCode` and `SoftwareApplication` includes the following terms from <https://schema.org>.  These terms are part of the CodeMeta specification and can be used without any prefix.
 
 ```{r}
 crosswalk <- "https://github.com/codemeta/codemeta/raw/master/crosswalk.csv"
 cw <- read_csv(crosswalk)
-cw %>% 
-  filter(grepl("schema:", `Parent Type`)) %>%
+cw %>%
+  filter(grepl("schema:(SoftwareSourceCode|SoftwareApplication|CreativeWork|Thing)", `Parent Type`)) %>%
   select(Property, Type, Description)  %>%
 knitr::kable("html", table.attr="class=\"table table-striped\"")
-
 ```
 
 These terms are all recognized properties of <https://schema.org/SoftwareSourceCode> or <https://schema.org/SoftwareApplication> Types. Note that while most properties take basic data types as values (`Text`, `URL`), several take other node types, such as `Person` or `Organization`.  Recommended fields for these node types in CodeMeta documents are given below.
+
+```{r}
+cw %>%
+  filter(grepl("schema:(Person|Thing)", `Parent Type`)) %>%
+  select(Property, Type, Description)  %>%
+knitr::kable("html", table.attr="class=\"table table-striped\"")
+```
 
 ## Codemeta terms
 
 The CodeMeta project also introduces the following additional properties, which lack clear equivalents in <https://schema.org> but can play an important role in software metadata records covered by the CodeMeta crosswalk.
 
 ```{r}
-cw %>% 
+cw %>%
   filter(grepl("codemeta:", `Parent Type`)) %>%
   select(Property, Type, Description)  %>%
 knitr::kable("html", table.attr="class=\"table table-striped\"")

--- a/content/terms.html
+++ b/content/terms.html
@@ -562,6 +562,90 @@ URL
 A link related to this object, e.g. related web pages
 </td>
 </tr>
+</tbody>
+</table>
+<p>These terms are all recognized properties of <a href="https://schema.org/SoftwareSourceCode" class="uri">https://schema.org/SoftwareSourceCode</a> or <a href="https://schema.org/SoftwareApplication" class="uri">https://schema.org/SoftwareApplication</a> Types. Note that while most properties take basic data types as values (<code>Text</code>, <code>URL</code>), several take other node types, such as <code>Person</code> or <code>Organization</code>. Recommended fields for these node types in CodeMeta documents are given below:</p>
+<table class="table table-striped">
+<thead>
+<tr>
+<th style="text-align:left;">
+Property
+</th>
+<th style="text-align:left;">
+Type
+</th>
+<th style="text-align:left;">
+Description
+</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="text-align:left;">
+description
+</td>
+<td style="text-align:left;">
+Text
+</td>
+<td style="text-align:left;">
+A description of the item.
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">
+identifier
+</td>
+<td style="text-align:left;">
+PropertyValue or URL
+</td>
+<td style="text-align:left;">
+The identifier property represents any kind of identifier for any kind of Thing, such as ISBNs, GTIN codes, UUIDs etc. Schema.org provides dedicated properties for representing many of these, either as textual strings or as URL (URI) links. See background notes for more details.
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">
+name
+</td>
+<td style="text-align:left;">
+Text
+</td>
+<td style="text-align:left;">
+The name of the item (software, Organization)
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">
+sameAs
+</td>
+<td style="text-align:left;">
+URL
+</td>
+<td style="text-align:left;">
+URL of a reference Web page that unambiguously indicates the item’s identity. E.g. the URL of the item’s Wikipedia page, Wikidata entry, or official website.
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">
+url
+</td>
+<td style="text-align:left;">
+URL
+</td>
+<td style="text-align:left;">
+URL of the item.
+</td>
+</tr>
+<tr>
+<td style="text-align:left;">
+relatedLink
+</td>
+<td style="text-align:left;">
+URL
+</td>
+<td style="text-align:left;">
+A link related to this object, e.g. related web pages
+</td>
+</tr>
 <tr>
 <td style="text-align:left;">
 givenName
@@ -641,7 +725,6 @@ Physical address of the item.
 </tr>
 </tbody>
 </table>
-<p>These terms are all recognized properties of <a href="https://schema.org/SoftwareSourceCode" class="uri">https://schema.org/SoftwareSourceCode</a> or <a href="https://schema.org/SoftwareApplication" class="uri">https://schema.org/SoftwareApplication</a> Types. Note that while most properties take basic data types as values (<code>Text</code>, <code>URL</code>), several take other node types, such as <code>Person</code> or <code>Organization</code>. Recommended fields for these node types in CodeMeta documents are given below.</p>
 </div>
 <div id="codemeta-terms" class="section level2">
 <h2>Codemeta terms</h2>


### PR DESCRIPTION
It's clearer for readers with no knowledge of schema.org.

Considering the text outside the table, it looks like you meant to do this in 63bc18a609d0a7c7165a23c05546a2e4b5dcc53a, but missed an update of the R code