### PR TITLE
added new tools to the tool page: codemeta-harvester, codemeta-server

### DIFF
--- a/content/tools.md
+++ b/content/tools.md
@@ -17,9 +17,10 @@ tool | language | codemeta version | maintainer | notes
 [CodeMeta file generator](https://gist.github.com/arfon/478b2ed49e11f984d6fb) | Ruby | 0.1.0 | [arfon](http://github.com/arfon) | (no support for current schema)
 [Bolognese](https://github.com/datacite/bolognese) | Ruby | 1.0.0 | [mfenner](https://github.com/mfenner) | primarily a tool for conversion between formats provided by DataCite, including codemeta and schema.org
 [codemetar](https://ropensci.github.io/codemetar) | R | 2.0.0 | [cboettig](https://github.com/cboettig) | Generate codemeta for R packages; + generic codemeta manipulation
-[codemetapy](https://github.com/proycon/codemetapy) | Python | 2.0.0 | [proycon](https://github.com/proycon) | Generate codemeta for Python packages
+[codemetapy](https://github.com/proycon/codemetapy) | Python | 2.0.0 | [proycon](https://github.com/proycon) | Generate codemeta for Python, NodeJS, Java packages and others; + generic codemeta manipulation
 [CodeMeta generator](https://codemeta.github.io/codemeta-generator/) | Javascript | 2.0.0 | [ProgVal](https://github.com/ProgVal) | Online form to create or complete a codemeta file
-
+[codemeta-harvester](https://github.com/proycon/codemeta-harvester) | POSIX Shell | 2.0.0 | [proycon](https://github.com/proycon) | Automatic software metadata conversion pipeline that uses codemetapy and other tools
+[codemeta-server](https://github.com/proycon/codemeta-server) | Python | 2.0.0 | [proycon](https://github.com/proycon) | Webservice offering an API (including SPARQL) and simple human web-interface so search and browse software metadata
 
 
 #### Integrations
@@ -42,6 +43,6 @@ Pending:
 - JOSS
 - Zenodo
 - DataCite
-- Figshare 
+- Figshare
 
 


### PR DESCRIPTION
I just released two new tools based on [codemetapy](https://github.com/proycon/codemetapy), which itself also saw a major  update release today:

* [codemeta-harvester](https://github.com/proycon/codemeta-harvester)  - A wrapper around codemetapy and other tools, provides a full automatic conversion pipeline to codemeta 
* [codemeta-server](https://github.com/proycon/codemeta-server) - A webservice/webapplication to search and browse codemeta (offers a SPARQL endpoint etc)..

This PR adds these tools to the list on the website. A live demo of the software can currently be found here: https://tools.dev.clariah.nl  ....  Instead of this list in markdown (which does have the benefit of great simplicity), it might also be an idea to set up codemeta-server and codemeta-harvester like for codemeta software (i.e. have the list of codemeta tools be automatically harvested and pulled from codemeta descriptions).
