### PR TITLE
Add automatic deployment to Github Pages + build on PRs 

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,26 @@
+name: Check Hugo build
+
+on:
+  # Runs on pushes targeting any branch and on pull requests
+  push:
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.108.0
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          DEBIAN_FRONTEND=noninteractive sudo apt-get update -y -qq
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y hugo
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Build with Hugo
+        run: |
+          hugo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,64 @@
+name: Deploy Hugo site to GitHub Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main", "master", "hugo", "ci"]  # TODO: decide on a final branch name
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HUGO_VERSION: 0.108.0
+    steps:
+      - name: Install Hugo CLI
+        run: |
+          DEBIAN_FRONTEND=noninteractive sudo apt-get update -y -qq
+          DEBIAN_FRONTEND=noninteractive sudo apt-get install -y hugo
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Build with Hugo
+        env:
+          # For maximum backward compatibility with Hugo modules
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          hugo \
+            --minify \
+            --baseURL "${{ steps.pages.outputs.base_url }}/"
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./public
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: ./public
+          path: ../website
 
   # Deployment job
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy Hugo site to GitHub Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main", "master", "hugo", "ci"]  # TODO: decide on a final branch name
+    branches: ["main", "master"]  # TODO: decide on a final branch name
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -3,5 +3,3 @@
 This website is written in [Hugo](https://hugodocs.info).  Hugo is the static website engine behind the wonderful RStudio package `blogdown`, and is fast, popular, and easy to install and theme. See the [Hugo docs](https://hugodocs.info) for a quick orientation on how the site is organized.  `blogdown` makes it easy to run Hugo from the RStudio editor and include R code in `.Rmd` content in Hugo sites.  
 
 To build and preview the site from RStudio, just use `blogdown::serve_site()`.  `blogdown::install_hugo()` will get you set up the first time.  
-
-Hugo source files are located on the `hugo` branch of the `codemeta.github.io` repository (now the default branch on GitHub).  So far we haven't set up automated builds, so deploying static sites on `*.github.io` repos is still a nuciance since the website must be on `master` branch.  Building this repo will create and write the static site to `../website`.  I recommend setting the upstream origin of `website` to `codemeta.github.io` master branch (e.g. checkout the master branch and copy `.git` dir into `website/` to deploy.)s

--- a/config.toml
+++ b/config.toml
@@ -64,3 +64,8 @@ publishDir = "../website"
     width = 50
     height = 50
     alt = "Logo"
+
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true


### PR DESCRIPTION
Also sets 'unsafe = true' because it is needed on newer versions of Hugo in order not to drop all the raw HTML we have in markdown files.

I propose to delete the currentl `master` branch (or rename it for history's sake) because it's not needed anymore; and rename the `hugo` branch to `master`.

Resolves #26 (cc @cboettig)