### PR TITLE
Add permalinks for 3.0 release

### DIFF
--- a/content/jsonld.md
+++ b/content/jsonld.md
@@ -12,9 +12,15 @@ CodeMeta uses JSON-LD to represent and translate between software metadata forma
 
 ## The JSON-LD Context File
 
-The current codemeta context file can be found at [![DOI](https://img.shields.io/badge/doi%3A-10.5063%2FSCHEMA%2FCODEMETA--2.0-blue.svg)](https://doi.org/10.5063/schema/codemeta-2.0)
+The current codemeta context file can be used from <https://w3id.org/codemeta/3.0> -- note that browsers will redirect using _content negotiation_ to a HTML page, while JSON-LD processors will get the JSON-LD context.
 
+### Released versions
 
+* <https://w3id.org/codemeta/3.0>
+* <https://doi.org/10.5063/schema/codemeta-2.0>
+* <https://doi.org/10.5063/schema/codemeta-1.0>
+
+### CodeMeta terms
 
 CodeMeta properties are built on and extend software properties from <https://schema.org>.  A list of all properties provided by the current CodeMeta `context` file can be found on the [terms](/terms) page. Here's an example [codemeta.json file](https://github.com/codemeta/codemetar/blob/master/codemeta.json) for the `codemetar` R package.  
 

--- a/content/terms.Rmd
+++ b/content/terms.Rmd
@@ -38,6 +38,9 @@ knitr::kable("html", table.attr="class=\"table table-striped\"")
 
 The CodeMeta project also introduces the following additional properties, which lack clear equivalents in <https://schema.org> but can play an important role in software metadata records covered by the CodeMeta crosswalk.
 
+* Namespace: <https://codemeta.github.io/terms/>
+  - **Warning**: This namespace will change to be w3id-based for CodeMeta 4.0
+
 ```{r}
 cw %>%
   filter(grepl("codemeta:", `Parent Type`)) %>%

--- a/content/terms.Rmd
+++ b/content/terms.Rmd
@@ -9,6 +9,9 @@ library("readr")
 library("dplyr")
 ```
 
+* Permalink: <https://w3id.org/codemeta/3.0>
+* CodeMeta version: 3.0
+
 ## Terms from Schema.org
 
 Recognized properties for CodeMeta `SoftwareSourceCode` and `SoftwareApplication` includes the following terms from <https://schema.org>.  These terms are part of the CodeMeta specification and can be used without any prefix.


### PR DESCRIPTION
See discussion in https://github.com/codemeta/codemeta/issues/236#issuecomment-1741090697

As this this modifies the 3.0 release-in-progress it uses the w3id PID from codemeta/codemeta#216 but the old <https://codemeta.github.io/terms/> namespace unless discussion agrees to also change these to w3id for 3.0
