### PR TITLE
Fix shortcode parameter for SPDX 2.3 crosswalk page

### DIFF
--- a/content/crosswalk/spdx2_3.md
+++ b/content/crosswalk/spdx2_3.md
@@ -19,4 +19,4 @@ SPDX 2.3 supports multiple serialization formats and often uses the following fi
 
 The crosswalk for the SPDX 2.3 SBOM is as follows:
 
-{{< crosswalk name="SPDX_2_3" >}}
+{{< crosswalk name="SPDX 2.3" >}}


### PR DESCRIPTION
Use the column name in crosswalk.csv ("SPDX 2.3") instead of the filename ("SPDX_2_3").

ref: https://github.com/codemeta/codemeta/blob/master/crosswalk.csv