### PR TITLE
Split Person and Thing terms into a separate table

### DIFF
--- a/content/terms.md
+++ b/content/terms.md
@@ -13,7 +13,6 @@ Recognized properties for CodeMeta `SoftwareSourceCode` and `SoftwareApplication
 These terms are all recognized properties of <https://schema.org/SoftwareSourceCode> or <https://schema.org/SoftwareApplication> Types.
 
 Note that while most properties take basic data types as values (`Text`, `URL`), several take other node types, such as `Person`, `Organization`, `Review`, or `Role`.
-
 Recommended fields for these node types in CodeMeta documents are given below.
 
 ### Schema.org Thing terms

--- a/content/terms.md
+++ b/content/terms.md
@@ -4,13 +4,33 @@ title: CodeMeta Terms
 
 ## Terms from Schema.org
 
+### Schema.org Software terms
+
 Recognized properties for CodeMeta `SoftwareSourceCode` and `SoftwareApplication` includes the following terms from <https://schema.org>.  These terms are part of the CodeMeta specification and can be used without any prefix.
 
 {{< properties-description matchParentType="schema:(SoftwareSourceCode|SoftwareApplication|CreativeWork|Thing)">}}
 
-These terms are all recognized properties of <https://schema.org/SoftwareSourceCode> or <https://schema.org/SoftwareApplication> Types. Note that while most properties take basic data types as values (`Text`, `URL`), several take other node types, such as `Person`, `Organization`, `Review`, or `Role`.  Recommended fields for these node types in CodeMeta documents are given below.
+These terms are all recognized properties of <https://schema.org/SoftwareSourceCode> or <https://schema.org/SoftwareApplication> Types.
 
-{{< properties-description matchParentType="schema:(Person|Thing|Review|Role)">}}
+Note that while most properties take basic data types as values (`Text`, `URL`), several take other node types, such as `Person`, `Organization`, `Review`, or `Role`.
+
+Recommended fields for these node types in CodeMeta documents are given below.
+
+### Schema.org Thing terms
+
+{{< properties-description matchParentType="schema:(Thing)">}}
+
+### Schema.org Person terms
+
+{{< properties-description matchParentType="schema:(Person)">}}
+
+### Schema.org Review terms
+
+{{< properties-description matchParentType="schema:(Review)">}}
+
+### Schema.org Role terms
+
+{{< properties-description matchParentType="schema:(Role)">}}
 
 ## CodeMeta terms
 


### PR DESCRIPTION
Reimplemented what described at https://github.com/codemeta/codemeta.github.io/issues/37#issuecomment-1412788595 to reduce confusion of duplicated appearance of terms in the same table.