### PR TITLE
Put RSS link inside <link> + Fix header display issue

### DIFF
--- a/themes/hugo-material/layouts/partials/head.html
+++ b/themes/hugo-material/layouts/partials/head.html
@@ -29,7 +29,7 @@
   {{ end }}
 
   {{ with .OutputFormats.Get "RSS" }}
-  <link rel="alternate" type="application/rss+xml" title="{{ printf '%s RSS feed' $.Site.Title }}" href="{{ .RelPermalink }}" />
+  <link rel="alternate" type="application/rss+xml" title='{{ printf "%s RSS feed" $.Site.Title }}' href="{{ .RelPermalink }}" />
   {{ end }}
   <link rel="canonical" href="{{ .Permalink }}">
 </head>


### PR DESCRIPTION
Currently these pages have a grey heading at the top of page, displaying ".xml" text:
- https://codemeta.github.io/index.html
- https://codemeta.github.io/crosswalk/

<img width="500" src="https://github.com/user-attachments/assets/6da8cfdf-30d0-4030-a544-940f740d579f" />

<img width="500" src="https://github.com/user-attachments/assets/0c4fe9c7-d0ee-44f7-90bd-746dab4da1b3" />

The text "/index.xml" is supposed to be the URL for RSS feed, inside `<link>` in `<head>` section and not being displayed.

This PR put the URL into the `<link>`, effectively fixes the display issue (higher priority) and bring back the RSS functionality (may be lower priority).