### PR TITLE
Update schema link to 3.1

### DIFF
--- a/content/developer-guide.md
+++ b/content/developer-guide.md
@@ -85,10 +85,10 @@ Tools will be created that assist in the generation of CodeMeta documents. For e
 
 ## Extending the CodeMeta Context
 
-CodeMeta explicitly defines the terms it uses from <http://schema.org>, rather than merely extending <http://schema.org> with a few additional terms.  To use additional terms from <http://schema.org> not listed on the [terms page](/terms/) (or terms from any other context), you must extend your context appropriately.  For instance, to combine CodeMeta (v3.0) with all terms available in schema.org, you would do:
+CodeMeta explicitly defines the terms it uses from <http://schema.org>, rather than merely extending <http://schema.org> with a few additional terms.  To use additional terms from <http://schema.org> not listed on the [terms page](/terms/) (or terms from any other context), you must extend your context appropriately.  For instance, to combine CodeMeta (v3.1) with all terms available in schema.org, you would do:
 
 ```json
-"@context": ["https://w3id.org/codemeta/3.0", "http://schema.org/"]
+"@context": ["https://w3id.org/codemeta/3.1", "http://schema.org/"]
 ```
 
 Note the default context should be listed last.  

--- a/content/jsonld.md
+++ b/content/jsonld.md
@@ -9,10 +9,11 @@ JSON-LD lead developer Manu Sporny explains how JSON-LD works in this short clip
 
 ## The JSON-LD Context File
 
-[![W3IDCodeMeta v3](https://img.shields.io/badge/W3ID-CodeMeta_v3-blue)](https://w3id.org/codemeta/3.0)
+[![Permanent Identifier](https://img.shields.io/badge/perma--id-https%3A%2F%2Fw3id.org%2Fcodemeta%2F3.1-blue.svg)](https://w3id.org/codemeta/3.1)
 
 Context file of released versions:
 
+- CodeMeta 3.1: <https://w3id.org/codemeta/3.1>
 - CodeMeta 3.0: <https://w3id.org/codemeta/3.0>
 - CodeMeta 2.0: <https://doi.org/10.5063/schema/codemeta-2.0>
 - CodeMeta 1.0: <https://doi.org/10.5063/schema/codemeta-1.0>

--- a/content/user-guide.md
+++ b/content/user-guide.md
@@ -15,7 +15,7 @@ Here is an example of a basic `codemeta.json` that you can put at the root of a 
 
 ```json
 {
-    "@context": "https://w3id.org/codemeta/3.0",
+    "@context": "https://w3id.org/codemeta/3.1",
     "type": "SoftwareSourceCode",
     "applicationCategory": "Biology",
     "codeRepository": "https://github.com/gem-pasteur/macsyfinder",
@@ -97,7 +97,7 @@ This should be added at the top level of the document, indicating that this indi
 
 ```json
 {
-    "@context": "https://w3id.org/codemeta/3.0",
+    "@context": "https://w3id.org/codemeta/3.1",
     "@type": "SoftwareSourceCode",
     "name": "CodemetaR",
 
@@ -116,7 +116,7 @@ JSON-LD operations can later *expand* this reference and *embed* the full inform
 
 ```json
 {
-    "@context": "https://w3id.org/codemeta/3.0",
+    "@context": "https://w3id.org/codemeta/3.1",
     "@type": "SoftwareSourceCode",
     "name": "CodemetaR",
 
@@ -143,7 +143,7 @@ We saw before a simple (root) SoftwareSourceCode object:
 
 ```json
 {
-    "@context": "https://w3id.org/codemeta/3.0",
+    "@context": "https://w3id.org/codemeta/3.1",
     "@type": "SoftwareSourceCode",
     "name": "CodemetaR"
 }
@@ -153,7 +153,7 @@ and this root object can refer to other objects, for example recommend a Softwar
 
 ```json
 {
-    "@context": "https://w3id.org/codemeta/3.0",
+    "@context": "https://w3id.org/codemeta/3.1",
     "@type": "SoftwareSourceCode",
     "name": "CodemetaR",
 
@@ -168,7 +168,7 @@ And you may in turn want to add attributes to this application:
 
 ```json
 {
-    "@context": "https://w3id.org/codemeta/3.0",
+    "@context": "https://w3id.org/codemeta/3.1",
     "@type": "SoftwareSourceCode",
     "name": "CodemetaR",
 
@@ -190,7 +190,7 @@ For example, the above code is not equivalent to:
 
 ```json
 {
-    "@context": "https://w3id.org/codemeta/3.0",
+    "@context": "https://w3id.org/codemeta/3.1",
     "@type": "SoftwareSourceCode",
     "name": "CodemetaR",
 
@@ -218,7 +218,7 @@ The CodeMeta GitHub repository defines tags to allow specific versions of a file
 appropriate context file, e.g.
 
 ```json
-"@context": "https://w3id.org/codemeta/3.0"
+"@context": "https://w3id.org/codemeta/3.1"
 ```
 
 Release candidate versions may be referred to consistently using their [git tag](https://github.com/codemeta/codemeta/tags) for the raw version, e.g. <https://raw.githubusercontent.com/codemeta/codemeta/2.0-rc/codemeta.jsonld>.  *Please do not refer to the raw GitHub URL for the master branch*, as this is subject to change and will not guarantee a stable metadata file.


### PR DESCRIPTION
- Add https://w3id.org/codemeta/3.1 link in JSON-LD page
- Update JSON examples to use 3.1 schema
- Also update the schema badge to use the same wording ("perma-id") as in README from codemeta/codemeta repo:
    https://github.com/codemeta/codemeta/blob/9458ead77eb8e5cc0df799bfd7f2a6d461525140/README.md?plain=1#L4
