### PR TITLE
Use {{% tag for Markdown shortcode

### DIFF
--- a/content/crosswalk/R.md
+++ b/content/crosswalk/R.md
@@ -6,4 +6,4 @@ date: "2017-06-01"
 
 The following table displays the crosswalk mapping of terms from the R package DESCRIPTION file to CodeMeta properties.
 
-{{< crosswalk name="R Package Description" >}}
+{{% crosswalk name="R Package Description" %}}

--- a/content/crosswalk/cargo.md
+++ b/content/crosswalk/cargo.md
@@ -10,4 +10,4 @@ The `Cargo.toml` file for each package is called its manifest. Cargo uses the me
 
 The manifest format is described in [the Cargo Book](https://doc.rust-lang.org/cargo/reference/manifest.html).
 
-{{< crosswalk name="Rust Package Manager" >}}
+{{% crosswalk name="Rust Package Manager" %}}

--- a/content/crosswalk/datacite.md
+++ b/content/crosswalk/datacite.md
@@ -6,4 +6,4 @@ date: "2017-06-01"
 
 [DataCite](https://datacite.org/) metadata is a standardized set of schema used when registering a DOI to ensure research outputs are findable, citable, and connected within the global scholarly ecosystem.
 
-{{< crosswalk name="DataCite" >}}
+{{% crosswalk name="DataCite" %}}

--- a/content/crosswalk/dcat-2.md
+++ b/content/crosswalk/dcat-2.md
@@ -10,6 +10,6 @@ Data Catalog Vocabulary (DCAT) is an RDF vocabulary designed to facilitate inter
 but DCAT 3 does not make DCAT 2 obsolete.
 DCAT 3 terms preserve backward compatibility with DCAT 2.
 
-{{< crosswalk name="DCAT-2" >}}
+{{% crosswalk name="DCAT-2" %}}
 
 See crosswalk for [DCAT 3](dcat-3).

--- a/content/crosswalk/dcat-3.md
+++ b/content/crosswalk/dcat-3.md
@@ -10,6 +10,6 @@ Data Catalog Vocabulary (DCAT) is an RDF vocabulary designed to facilitate inter
 DCAT 3 supersedes DCAT 2, but DCAT 3 does not make DCAT 2 obsolete.
 DCAT 3 terms preserve backward compatibility with DCAT 2.
 
-{{< crosswalk name="DCAT-3" >}}
+{{% crosswalk name="DCAT-3" %}}
 
 See crosswalk for [DCAT 2](dcat-2).

--- a/content/crosswalk/debian.md
+++ b/content/crosswalk/debian.md
@@ -6,4 +6,4 @@ date: "2017-06-01"
 
 The [Debian package system](https://www.debian.org/doc/manuals/debian-reference/ch02.en.html#_archive_meta_data) defines archive metadata that is used by the popular [`apt`](https://wiki.debian.org/Apt) package management system on Debian and Ubuntu Linux distributions.
 
-{{< crosswalk name="Debian Package" >}}
+{{% crosswalk name="Debian Package" %}}

--- a/content/crosswalk/doap.md
+++ b/content/crosswalk/doap.md
@@ -6,4 +6,4 @@ date: "2017-06-01"
 
 [DOAP](https://github.com/ewilderj/doap) (Description of a Project) is an XML/RDF vocabulary to describe software projects, and in particular open source projects.
 
-{{< crosswalk name="DOAP" >}}
+{{% crosswalk name="DOAP" %}}

--- a/content/crosswalk/dublincore.md
+++ b/content/crosswalk/dublincore.md
@@ -5,4 +5,4 @@ image: "/img/dcmi.png"
 
 [Dublin Core](https://www.dublincore.org/) vocabulary (or the Dublin Core Metadata Terms - DCMT) is a widely used, general-purpose metadata vocabulary for describing any type of resource.
 
-{{< crosswalk name="Dublin Core" >}}
+{{% crosswalk name="Dublin Core" %}}

--- a/content/crosswalk/figshare.md
+++ b/content/crosswalk/figshare.md
@@ -5,4 +5,4 @@ image: "/img/figshare.jpg"
 
 [figshare](https://figshare.com) is a general purpose scientific data repository that provides [DataCite](https://datacite.org/) DOIs.
 
-{{< crosswalk name="Figshare" >}}
+{{% crosswalk name="Figshare" %}}

--- a/content/crosswalk/github.md
+++ b/content/crosswalk/github.md
@@ -8,4 +8,4 @@ date: "2017-06-01"
 
 [GitHub API](https://docs.github.com/en/rest) provides a programmatic way to retrieve repository metadata.
 
-{{< crosswalk name="GitHub" >}}
+{{% crosswalk name="GitHub" %}}

--- a/content/crosswalk/java.md
+++ b/content/crosswalk/java.md
@@ -6,4 +6,4 @@ date: "2017-06-01"
 
 [Maven](https://maven.apache.org/what-is-maven.html) is a popular packaging/build system for Java-based projects.
 
-{{< crosswalk name="Java (Maven)" >}}
+{{% crosswalk name="Java (Maven)" %}}

--- a/content/crosswalk/node.md
+++ b/content/crosswalk/node.md
@@ -8,4 +8,4 @@ The `npm` package manager for JavaScript [defines](https://docs.npmjs.com/files/
 
 `npm` is the default package manager for the JavaScript runtime environment Node.js.
 
-{{< crosswalk name="NodeJS" >}}
+{{% crosswalk name="NodeJS" %}}

--- a/content/crosswalk/publiccode.md
+++ b/content/crosswalk/publiccode.md
@@ -6,4 +6,4 @@ date: "2025-08-10"
 
 The [publiccode.yml](https://github.com/publiccodeyml/publiccode.yml) spec defines metadata for public sector OSS software projects, used by national and international catalogs to index, present, and facilitate the reuse of open source software developed by or for public administrations.
 
-{{< crosswalk name="publiccode" >}}
+{{% crosswalk name="publiccode" %}}

--- a/content/crosswalk/python.md
+++ b/content/crosswalk/python.md
@@ -6,4 +6,4 @@ date: "2017-06-01"
 
 [Python `distutils`](https://docs.python.org/3.6/distutils/) allows users to associate a range of metadata information when packaging and distributing Python-based applications or source code.  
 
-{{< crosswalk name="Python Distutils (PyPI)" >}}
+{{% crosswalk name="Python Distutils (PyPI)" %}}

--- a/content/crosswalk/ruby.md
+++ b/content/crosswalk/ruby.md
@@ -6,4 +6,4 @@ date: "2017-06-01"
 
 Ruby gems [specify metadata](http://guides.rubygems.org/specification-reference/) in a `.gemspec` file.
 
-{{< crosswalk name="Ruby Gem" >}}
+{{% crosswalk name="Ruby Gem" %}}

--- a/content/crosswalk/spdx-2-3.md
+++ b/content/crosswalk/spdx-2-3.md
@@ -19,4 +19,4 @@ SPDX 2.3 supports multiple serialization formats and often uses the following fi
 
 The crosswalk for the SPDX 2.3 SBOM is as follows:
 
-{{< crosswalk name="SPDX 2.3" >}}
+{{% crosswalk name="SPDX 2.3" %}}

--- a/content/crosswalk/swo.md
+++ b/content/crosswalk/swo.md
@@ -8,4 +8,4 @@ The [Software Ontology (SWO)](http://theswo.sourceforge.net/) is a resource for 
 SWO is part of the JISC funded [SWORD project](https://www.software.ac.uk/blog/sword-software-ontology-research-description) (Software Ontology for Resource Description), an inter-disciplinary effort to capture software descriptions used in the preservation of data.
 The work is a collaboration between the European Bioinformatics Institute and the University of Manchester.
 
-{{< crosswalk name="Software Ontology" >}}
+{{% crosswalk name="Software Ontology" %}}

--- a/content/crosswalk/trove.md
+++ b/content/crosswalk/trove.md
@@ -5,4 +5,4 @@ image: "/img/sourceforge.png"
 
 [Trove](https://web.archive.org/web/20240420104333/https://sourceforge.net/p/easyhtml5/tracinst/Software%20Map%20and%20Trove/#what-is-trove) is the system used by [SourceForge.net](https://sourceforge.net/) software development hosting platform to classify software projects.
 
-{{< crosswalk name="Trove Software Map" >}}
+{{% crosswalk name="Trove Software Map" %}}

--- a/content/crosswalk/wikidata.md
+++ b/content/crosswalk/wikidata.md
@@ -9,4 +9,4 @@ date: "2017-06-04"
 Surprisingly Wikidata does not have a native JSON-LD format,
 [distributing in plain JSON and RDF dumps](https://www.wikidata.org/wiki/Wikidata:Database_download).
 
-{{< crosswalk name="Wikidata" >}}
+{{% crosswalk name="Wikidata" %}}

--- a/content/crosswalk/zenodo.md
+++ b/content/crosswalk/zenodo.md
@@ -5,4 +5,4 @@ image: "/img/zenodo.jpg"
 
 [Zenodo.org](https://zenodo.org) is a data archive based at CERN which is popularly used to archive and provide DOIs to academic software from GitHub, as described in the official GitHub guide to [Making your code citable](https://guides.github.com/activities/citable-code/).
 
-{{< crosswalk name="Zenodo" >}}
+{{% crosswalk name="Zenodo" %}}

--- a/content/jsonld.md
+++ b/content/jsonld.md
@@ -5,7 +5,7 @@ title: "The CodeMeta JSON-LD Representation"
 CodeMeta uses JSON-LD to represent and translate between software metadata formats.
 JSON-LD lead developer Manu Sporny explains how JSON-LD works in this short clip:
 
-{{< youtube Tm3fD89dqRE >}}
+{{% youtube Tm3fD89dqRE %}}
 
 ## The JSON-LD Context File
 

--- a/content/terms.md
+++ b/content/terms.md
@@ -8,7 +8,7 @@ title: CodeMeta Terms
 
 Recognized properties for CodeMeta `SoftwareSourceCode` and `SoftwareApplication` includes the following terms from <https://schema.org>.  These terms are part of the CodeMeta specification and can be used without any prefix.
 
-{{< properties-description matchParentType="schema:(SoftwareSourceCode|SoftwareApplication|CreativeWork|Thing)">}}
+{{% properties-description matchParentType="schema:(SoftwareSourceCode|SoftwareApplication|CreativeWork|Thing)"%}}
 
 These terms are all recognized properties of <https://schema.org/SoftwareSourceCode> or <https://schema.org/SoftwareApplication> Types.
 
@@ -17,24 +17,24 @@ Recommended fields for these node types in CodeMeta documents are given below.
 
 ### Schema.org Thing terms
 
-{{< properties-description matchParentType="schema:(Thing)">}}
+{{% properties-description matchParentType="schema:(Thing)"%}}
 
 ### Schema.org Person terms
 
-{{< properties-description matchParentType="schema:(Person)">}}
+{{% properties-description matchParentType="schema:(Person)"%}}
 
 ### Schema.org Review terms
 
-{{< properties-description matchParentType="schema:(Review)">}}
+{{% properties-description matchParentType="schema:(Review)"%}}
 
 ### Schema.org Role terms
 
-{{< properties-description matchParentType="schema:(Role)">}}
+{{% properties-description matchParentType="schema:(Role)"%}}
 
 ## CodeMeta terms
 
 The CodeMeta project also introduces the following additional properties, which lack clear equivalents in <https://schema.org> but can play an important role in software metadata records covered by the CodeMeta crosswalk.
 
-{{< properties-description matchParentType="codemeta:">}}
+{{% properties-description matchParentType="codemeta:"%}}
 
 Please suggest additional terms or adjustments to this representation in the [CodeMeta issues](https://github.com/codemeta/codemeta/issues).


### PR DESCRIPTION
`crosswalk` and `properties-description` are shortcodes defined in Markdown format (see: layouts/shortcodes ), so we need to use `{{% .. %}}` tag or (newer versions of) Hugo will complain about "no compatible template found for shortcode".

Tested with Hugo [v0.152.0](https://github.com/gohugoio/hugo/releases/tag/v0.152.2) (latest, as of 30 Oct 2025) and [v0.108.0](https://github.com/gohugoio/hugo/releases/tag/v0.108.0) (as used in current CI).