### PR TITLE
Fix shortcode syntax and tabbing for latest hugo version

### DIFF
--- a/content/news.md
+++ b/content/news.md
@@ -3,4 +3,4 @@ title: Codemeta News
 layout: single
 ---
 
-{{< news >}}
+{{% news %}}

--- a/layouts/shortcodes/news.md
+++ b/layouts/shortcodes/news.md
@@ -18,13 +18,13 @@
 
 {{ $combi := sort $combi ".pubDate" "desc" }}
 
-    {{ range $combi }}
-    <li class="ps-2 pb-2">
-      <h3><a class="list-group-item newslink p-2" href="{{ .link }}">{{ .title }}</a></h3>
-      <small class="ps-2 text-secondary-emphasis">{{ .pubDate | time.Format "Jan 02, 2006 3:04 PM MST"  }}</small>
-      <div class="ps-2 pt-2">{{ .description }}</div>
-    </li>
-    {{ end }}
+{{ range $combi }}
+  <li class="ps-2 pb-2">
+    <h3><a class="list-group-item newslink p-2" href="{{ .link }}">{{ .title }}</a></h3>
+    <small class="ps-2 text-secondary-emphasis">{{ .pubDate | time.Format "Jan 02, 2006 3:04 PM MST"  }}</small>
+    <div class="ps-2 pt-2">{{ .description }}</div>
+  </li>
+{{ end }}
   </ul>
 <script src="../js/news.js"></script>
 <script>


### PR DESCRIPTION
Similar to pr #85, the include syntax changed for latest hugo
and I missed this one somehow. Also there are now different
standards for spacing or something hence the actual shortcode
needed fixing as well.